### PR TITLE
Fix nightly regression due to stabilization of Iterator::flatten

### DIFF
--- a/src/payment_request.rs
+++ b/src/payment_request.rs
@@ -198,14 +198,14 @@ impl PaymentRequest {
 
     /// Return the extra routing info.
     pub fn routing_info(&self) -> Vec<ExtraHop> {
-        self.tags
-            .iter()
-            .filter_map(|v| match *v {
-                Tag::RoutingInfo { ref path } => Some(path.to_owned()),
-                _ => None,
-            })
-            .flatten()
-            .collect_vec()
+        Itertools::flatten(
+            self.tags
+                .iter()
+                .filter_map(|v| match *v {
+                    Tag::RoutingInfo { ref path } => Some(path.to_owned()),
+                    _ => None,
+                })
+         ).collect_vec()
     }
 
     /// Return the min_final_cltv_expiry if any.


### PR DESCRIPTION
This fixes a regression in nightly due to the pending stabilization of `Iterator::flatten`.
See https://github.com/rust-lang/rust/pull/51511 for details.